### PR TITLE
feat: `quickswitch` alias wrongly assigned to `release`

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -106,8 +106,8 @@ pub enum Commands {
     Pr(PRCommand),
     Pull(PullCommand),
     Push(PushCommand),
-    #[clap(aliases = &["quickswitch", "quick_switch"])]
     Release(ReleaseCommand),
+    #[clap(aliases = &["quickswitch", "quick_switch"])]
     QuickSwitch(QuickSwitchCommand),
     #[clap(aliases = &["rebase_default", "refresh_branch", "refresh-branch"])]
     RebaseDefault(RebaseDefaultCommand),


### PR DESCRIPTION
Closes: #31
